### PR TITLE
fix(models): add STREAK_TYPE_TYING to OverallRecordType

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "griddy"
-version = "0.8.3"
+version = "0.8.4"
 description = "Python SDK for football data sources."
 authors = [
     {name = "John Griebel", email = "john@thistlegrow.com"}

--- a/src/griddy/nfl/models/entities/overall_record.py
+++ b/src/griddy/nfl/models/entities/overall_record.py
@@ -25,6 +25,7 @@ OverallRecordType = Literal[
     "T",
     "STREAK_TYPE_WINNING",
     "STREAK_TYPE_LOSING",
+    "STREAK_TYPE_TYING",
 ]
 r"""Type of current streak"""
 


### PR DESCRIPTION
## Summary
- Add missing `"STREAK_TYPE_TYING"` value to `OverallRecordType` Literal in `overall_record.py`
- Bump package version from 0.8.3 → 0.8.4

Closes #128

## Test plan
- [ ] Verify Pydantic validation accepts `"STREAK_TYPE_TYING"` streak type from the NFL standings API
- [ ] Run `pytest` to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)